### PR TITLE
pick [skyrings] Update ifspeed.sh

### DIFF
--- a/src/collectd_scripts/ifspeed.sh
+++ b/src/collectd_scripts/ifspeed.sh
@@ -5,7 +5,7 @@ re='^[0-9]+$'
 ESC_HOSTNAME=`echo $HOSTNAME | tr . _`
 sigma_numerator=0.00
 sigma_denominator=0.00
-for INT_LIST in `ls /sys/class/net | sort | uniq`
+for INT_LIST in `ls /sys/class/net | sort | uniq | grep -v "bonding_masters"`
 do
  ethString=`sudo ethtool $INT_LIST`
  speed=`echo $ethString | grep Speed | sed 's/^.*Speed: \([0-9]\+\).*$/\1/'`


### PR DESCRIPTION
Fixes issue when using bond device and SELinux, collectd passes
non existing network device "bonding_masters" as parameter to
"/sbin/ethtool" which triggers SELinux alert.

Signed-off-by: Tomas Petr tpetr@redhat.com